### PR TITLE
delete redundant content and modify syntax error

### DIFF
--- a/docs/manual/log_description.md
+++ b/docs/manual/log_description.md
@@ -1,6 +1,6 @@
 # 日志说明
 
-FISCO BCOS的所有群组日志都输出log目录下到`log_%YYYY%mm%dd%HH.%MM`的文件中，且定制了日志格式，方便用户通过日志查看各群组状态。日志配置说明请参考[日志配置说明](./configuration.html#id6)
+FISCO BCOS的所有群组日志都输出到log目录下`log_%YYYY%mm%dd%HH.%MM`的文件中，且定制了日志格式，方便用户通过日志查看各群组状态。日志配置说明请参考[日志配置说明](./configuration.html#id6)
 
 ## 日志格式
 

--- a/docs/manual/node_management.md
+++ b/docs/manual/node_management.md
@@ -32,9 +32,6 @@ FISCO BCOS引入了[游离节点、观察者节点和共识节点](../design/sec
 ```
 
 ```bash
-# 设节点位于~/fisco/nodes/192.168.0.1/node0目录下
-$ mkdir -p ~/fisco && cd ~/fisco
-
 # 获取节点Node ID（设节点目录为~/nodes/192.168.0.1/node0/）
 $ cat ~/fisco/nodes/192.168.0.1/node0/conf/node.nodeid
 7a056eb611a43bae685efd86d4841bc65aefafbf20d8c8f6028031d67af27c36c5767c9c79cff201769ed80ff220b96953da63f92ae83554962dc2922aa0ef50
@@ -131,7 +128,7 @@ $ cd nodes/127.0.0.1/
 $ cp node0/config.ini node0/start.sh node0/stop.sh node2/
 ```
 
-4 . 修改`node2/config.ini`。对于`[rpc]`模块，修改`listen_ip`、`channel_listen_port`和`jsonrpc_listen_port`；对于`[p2p]`模块，修改`listen_port`并在`node.`中增加自身节点信息；
+4 . 修改`node2/config.ini`。对于`[rpc]`模块，修改`channel_listen_port`和`jsonrpc_listen_port`；对于`[p2p]`模块，修改`listen_port`并在`node.`中增加自身节点信息；
 
 ```
 $ vim node2/config.ini

--- a/en/docs/manual/log_description.md
+++ b/en/docs/manual/log_description.md
@@ -138,3 +138,4 @@ The core module keywords in the FISCO BCOS log are as follows:
 | Storage middleware module |STORAGE|
 | External Storage engine |SQLConnectionPool|
 | MySQL Storage engine  |ZdbStorage|
+

--- a/en/docs/manual/node_management.md
+++ b/en/docs/manual/node_management.md
@@ -33,9 +33,6 @@ For example, to convert the specified nodes to Sealer, Observer, and RemoveNode,
 ```
 
 ```bash
-# to set the node in the ~/fisco/nodes/192.168.0.1/node0 directory
-$ mkdir -p ~/fisco && cd ~/fisco
-
 # to get Node ID (to set the directory as ~/nodes/192.168.0.1/node0/）
 $ cat ~/fisco/nodes/192.168.0.1/node0/conf/node.nodeid
 7a056eb611a43bae685efd86d4841bc65aefafbf20d8c8f6028031d67af27c36c5767c9c79cff201769ed80ff220b96953da63f92ae83554962dc2922aa0ef50
@@ -136,7 +133,7 @@ $ cd nodes/127.0.0.1/
 $ cp node0/config.ini node0/start.sh node0/stop.sh node2/
 ```
 
-4 . modify `node2/config.ini`. For `[rpc]` model, modify `listen_ip`, `channel_listen_port` and `jsonrpc_listen_port`; for `[p2p]` model, modify `listen_port` and add its node information in `node.`.
+4 . modify `node2/config.ini`. For `[rpc]` model, modify `channel_listen_port` and `jsonrpc_listen_port`; for `[p2p]` model, modify `listen_port` and add its node information in `node.`.
 
 ```eval_rst
 .. note::


### PR DESCRIPTION
1. 修改 `docs/manual/log_description.md`  中文字语法错误：将文字 `...群组日志都输出log目录下到...` 修改为 `...群组日志都输出到log目录下...`
2. 删除 `docs/manual/node_management.md` 中多余的操作：`mkdir -p ~/fisco && cd ~/fisco` 该条操作命令对下面的操作没有任何作用，`mkdir -p ~/fisco` 甚至会报错
3. 删除 `docs/manual/node_management.md` 多余的描述：拷贝 `node0/config.ini` 文件之后，应该不需要修改 `listen_ip`，因为 `listen_ip` 的值为 `127.0.0.1`，修改前后一致。