### PR TITLE
docs(java_sdk): 更新maven的版本依赖

### DIFF
--- a/docs/sdk/java_sdk.md
+++ b/docs/sdk/java_sdk.md
@@ -40,7 +40,7 @@ compile ('org.fisco-bcos:web3sdk:2.1.0')
 <dependency>
     <groupId>org.fisco-bcos</groupId>
     <artifactId>web3sdk</artifactId>
-    <version>2.1.0</version>
+    <version>2.4.0</version>
 </dependency>
 ```
 由于引入了以太坊的solidity编译器相关jar包，需要在Java应用的gradle配置文件build.gradle中添加以太坊的远程仓库。


### PR DESCRIPTION
fisco国密2.4版本，web3sdk如果还是按文档上使用2.1版本，send交易测试报错java.lang.IllegalStateException: point not in normal form，更新为2.4版本ok