### PR TITLE
docs(group_use_cases.md): 修改注释

### DIFF
--- a/docs/manual/group_use_cases.md
+++ b/docs/manual/group_use_cases.md
@@ -235,7 +235,7 @@ $ curl -LO https://github.com/FISCO-BCOS/console/releases/download/v1.0.9/downlo
 # 进入控制台操作目录
 $ cd console
 
-# 拷贝group2节点证书到控制台配置目录
+# 拷贝sdk证书到控制台配置目录
 $ cp ~/fisco/nodes/127.0.0.1/sdk/* conf/
 
 # 获取node0的channel_listen_port


### PR DESCRIPTION
按上下文，不是拷贝group2证书，而是拷贝所有节点的证书，注释不准确