### PR TITLE
ls 命令输出不了目录结构

### DIFF
--- a/docs/enterprise_tools/tutorial_one_click.md
+++ b/docs/enterprise_tools/tutorial_one_click.md
@@ -94,7 +94,7 @@ cd ~/generator && bash ./scripts/install.sh
 
 ```bash
 cd ~/generator
-ls ./tmp_one_click
+tree -L 2 ./tmp_one_click
 ```
 
 ```bash
@@ -184,7 +184,7 @@ bash ./one_click_generator.sh -b ./tmp_one_click
 查看执行后的一键部署模板文件夹：
 
 ```bash
-ls ./tmp_one_click
+tree -L 2 ./tmp_one_click
 ```
 
 ```bash


### PR DESCRIPTION
ls ./tmp_one_click

无法输出如下目录结构

tmp_one_click # 用户指定进行一键部署操作的文件夹
├── agencyA # 机构A目录，命令执行后会在该目录下生成机构A的节点及相关文件
│ └── node_deployment.ini # 机构A节点配置文件，一键部署命令会根据该文件生成相应节点
└── agencyB # 机构B目录，命令执行后会在该目录下生成机构B的节点及相关文件
└── node_deployment.ini # 机构B节点配置文件，一键部署命令会根据该文件生成相应节点

需要修改为tree命令