### PR TITLE
修改文档中准备扩展节点资源目录

### DIFF
--- a/3.x/zh_CN/docs/tutorial/air/expand_node.md
+++ b/3.x/zh_CN/docs/tutorial/air/expand_node.md
@@ -33,7 +33,7 @@ Air版本区块链扩容时，需要提前准备证书和配置文件，用于�
 
 ```shell
 # 进入操作目录(Note: 进行本操作之前，请参考【搭建第一个区块链网络节点】部署一条Air版FISCO BCOS区块链)
-$ cd ~/fisco/nodes
+$ cd ~/fisco
 
 # 创建扩容配置存放目录
 $ mkdir config


### PR DESCRIPTION
准备扩展节点资源创建目录时不必进入nodes目录（“cd ~/fisco/nodes”），config目录应当直接位于fisco/下而非nodes目录下
原始操作在拷贝根证书、根证书私钥（cp -r nodes/ca config）时报错：“找不到文件”
修改后完成所有操作