### PR TITLE
Update certificate_list.md

### DIFF
--- a/2.x/docs/manual/certificate_list.md
+++ b/2.x/docs/manual/certificate_list.md
@@ -253,7 +253,7 @@ $ bash stop.sh && bash start.sh
 $ curl -X POST --data '{"jsonrpc":"2.0","method":"getPeers","params":[1],"id":1}' http://127.0.0.1:8545 |jq
 ```
 
-可看到只与两个节点建立的连接，未与node1建立连接
+可看到只与两个节点建立的连接，未与node3建立连接
 
 ``` json
 {


### PR DESCRIPTION
此处官方文档是配置白名单，node0拒绝与node1,node2之外的节点连接，那么就是拒绝与node3节点连接，所以可看到只与node1、node2建立了连接，未与node3建立连接。