### PR TITLE
 protocol_description.md中网络数据包Data的描述中长度描述错误

### DIFF
--- a/2.x/docs/design/protocol_description.md
+++ b/2.x/docs/design/protocol_description.md
@@ -109,7 +109,7 @@ v2.0.0-rc2扩展了**群组ID和模块ID**范围，**最多支持32767个群组*
 | ModuleID (MID)   | uint16_t | 模块ID，范围1-65535   |
 | PacketType | uint16_t     | 数据包类型，同一模块ID下的子协议标识  |
 | Seq        | uint32_t     | 数据包序列号，每个数据包自增         |
-| Data       | vector<byte> | 数据本身，长度为lenght-12           |
+| Data       | vector<byte> | 数据本身，长度为lenght-16           |
 
 **补充**
 


### PR DESCRIPTION
protocol_description.md中P2PMessage网络数据包结构中对Data描述中  数据本身，长度为length-12应该改为length-16，数据前面的几个部分总长度为16字节的