### PR TITLE
Update installation.md

### DIFF
--- a/3.x/zh_CN/docs/tutorial/pro/installation.md
+++ b/3.x/zh_CN/docs/tutorial/pro/installation.md
@@ -522,11 +522,11 @@ generated/chain0
 
 ### 4.5部署区块链节点监控服务
 
-RPC服务和Gateway服务和node服务均部署完成后，可部署区块链节点监控服务。在建链工具BcosProBuilder目录下，执行如下命令，可部署并启动区块链节点监控服务。
+RPC服务和Gateway服务和node服务均部署完成后，可部署区块链节点监控服务。在建链工具BcosBuilder/pro目录下，执行如下命令，可部署并启动区块链节点监控服务。
 
 ```shell
 # 进入操作目录
-cd ~/fisco/BcosProBuilder
+cd ~/fisco/BcosBuilder/pro
 
 # 部署并启动区块链节点服务
 python3 build_chain.py chain -o deploy -t monitor


### PR DESCRIPTION
将4.5节中的文件目录由 ”BcosProBuilder目录“改为“BcosBuilder/pro目录”，在搭建测试中，文件夹名BcosBuilder非BcosProBuilder。